### PR TITLE
move subtype to base model

### DIFF
--- a/activities/runkeeper/models.py
+++ b/activities/runkeeper/models.py
@@ -61,7 +61,6 @@ class DataFile(BaseDataFile):
     user_data = models.ForeignKey(UserData, related_name='datafiles')
     task = models.ForeignKey(DataRetrievalTask,
                              related_name='datafile_runkeeper')
-    subtype = models.CharField(max_length=64, blank=True, null=True)
 
     def __unicode__(self):
         return '%s:%s:%s' % (self.user_data.user, 'runkeeper', self.file)

--- a/activities/twenty_three_and_me/migrations/0005_datafile_subtype.py
+++ b/activities/twenty_three_and_me/migrations/0005_datafile_subtype.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('twenty_three_and_me', '0004_userdata_genome_file'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='datafile',
+            name='subtype',
+            field=models.CharField(max_length=64, null=True, blank=True),
+        ),
+    ]

--- a/data_import/migrations/0003_auto_20151120_0543.py
+++ b/data_import/migrations/0003_auto_20151120_0543.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('data_import', '0002_auto_20150501_0616'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='testdatafile',
+            name='subtype',
+            field=models.CharField(max_length=64, null=True, blank=True),
+        ),
+    ]

--- a/data_import/models.py
+++ b/data_import/models.py
@@ -226,10 +226,16 @@ class BaseDataFile(models.Model):
     file = models.FileField(upload_to=get_upload_path, max_length=1024)
     task = None
     user_data = None
-    subtype = None
+    subtype = models.CharField(max_length=64, blank=True, null=True)
 
     class Meta:
         abstract = True
+
+    def save(self, *args, **kwargs):
+        if not self.subtype and hasattr(self, 'default_subtype'):
+            self.subtype = self.default_subtype
+
+        super(BaseDataFile, self).save(*args, **kwargs)
 
     def __unicode__(self):
         return '%s:%s:%s' % (self.user_data.user, self.source, self.file)
@@ -273,4 +279,3 @@ class TestDataFile(BaseDataFile):
     task = models.ForeignKey(DataRetrievalTask,
                              related_name='datafile_test_data_file',
                              null=True, blank=True)
-    subtype = models.CharField(max_length=64, default='')

--- a/studies/american_gut/migrations/0006_auto_20151120_0543.py
+++ b/studies/american_gut/migrations/0006_auto_20151120_0543.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('american_gut', '0005_auto_20151008_2354'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='datafile',
+            name='subtype',
+            field=models.CharField(max_length=64, null=True, blank=True),
+        ),
+    ]

--- a/studies/american_gut/models.py
+++ b/studies/american_gut/models.py
@@ -71,8 +71,8 @@ class DataFile(BaseDataFile):
     user_data = models.ForeignKey(UserData)
     task = models.ForeignKey(DataRetrievalTask,
                              related_name='datafile_american_gut')
-    subtype = models.CharField(max_length=64,
-                               default='microbiome-16S-and-surveys')
+
+    default_subtype = 'microbiome-16S-and-surveys'
 
     def __unicode__(self):
         return '%s:%s:%s' % (self.user_data.user, 'american_gut', self.file)

--- a/studies/go_viral/migrations/0005_auto_20151120_0543.py
+++ b/studies/go_viral/migrations/0005_auto_20151120_0543.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('go_viral', '0004_userdata_data'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='datafile',
+            name='subtype',
+            field=models.CharField(max_length=64, null=True, blank=True),
+        ),
+    ]

--- a/studies/go_viral/models.py
+++ b/studies/go_viral/models.py
@@ -73,7 +73,8 @@ class DataFile(BaseDataFile):
     user_data = models.ForeignKey(UserData)
     task = models.ForeignKey(DataRetrievalTask,
                              related_name='datafile_go_viral')
-    subtype = models.CharField(max_length=64, default='sickness-reports')
+
+    default_subtype = 'sickness-reports'
 
     def __unicode__(self):
         return '%s:%s:%s' % (self.user_data.user, 'go_viral', self.file)

--- a/studies/pgp/models.py
+++ b/studies/pgp/models.py
@@ -77,8 +77,6 @@ class DataFile(BaseDataFile):
 
     user_data = models.ForeignKey(UserData)
     task = models.ForeignKey(DataRetrievalTask, related_name='datafile_pgp')
-    # this study already has multiple subtypes so we can't default to one here
-    subtype = models.CharField(max_length=64, blank=True, null=True)
 
     def __unicode__(self):
         return '%s:%s:%s' % (self.user_data.user, 'pgp', self.file)

--- a/studies/wildlife/migrations/0002_auto_20151120_0543.py
+++ b/studies/wildlife/migrations/0002_auto_20151120_0543.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('wildlife', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='datafile',
+            name='subtype',
+            field=models.CharField(max_length=64, null=True, blank=True),
+        ),
+    ]

--- a/studies/wildlife/models.py
+++ b/studies/wildlife/models.py
@@ -53,8 +53,8 @@ class DataFile(BaseDataFile):
     user_data = models.ForeignKey(UserData)
     task = models.ForeignKey(DataRetrievalTask,
                              related_name='datafile_wildlife')
-    subtype = models.CharField(max_length=64,
-                               default='wildlife')
+
+    default_subtype = 'wildlife'
 
     def __unicode__(self):
         return '%s:%s:%s' % (self.user_data.user, 'wildlife', self.file)


### PR DESCRIPTION
figured out a way to do this by keeping the defaults in the models as a field and overriding `save` in the base, but only after futzing around with using a callable that was part of the class (which doesn't work).