### PR TITLE
Add hosted Piwik tracking

### DIFF
--- a/open_humans/templates/base.html
+++ b/open_humans/templates/base.html
@@ -137,6 +137,7 @@
 
     {% block extra_modals %}{% endblock %}
 
+    {% include 'partials/piwik.html' %}
     {% include 'partials/usersnap.html' %}
   </body>
 </html>

--- a/open_humans/templates/partials/piwik.html
+++ b/open_humans/templates/partials/piwik.html
@@ -1,0 +1,13 @@
+<script type="text/javascript">
+var _paq = _paq || [];
+_paq.push(['trackPageView']);
+_paq.push(['enableLinkTracking']);
+(function() {
+var u="//open-humans.piwikpro.com/";
+_paq.push(['setTrackerUrl', u+'piwik.php']);
+_paq.push(['setSiteId', 1]);
+var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+g.type='text/javascript'; g.async=true; g.defer=true; g.src=u+'piwik.js'; s.parentNode.insertBefore(g,s);
+})();
+</script>
+<noscript><p><img src="//open-humans.piwikpro.com/piwik.php?idsite=1" style="border:0;" alt="" /></p></noscript>


### PR DESCRIPTION
This pull request would add the Piwik tracking code to Open Humans.

Piwik is a [privacy-conscious](http://piwik.org/privacy/) analytics company; their main offering is open source and can be self-hosted but I think it's worth paying for them to host it ($29.95/month).

I think we're at a size where having insight into who's coming to the site and where we're getting traffic from will be useful.

Thoughts @madprime? You can login via Meldium to see the interface, we have a 30 day trial.