### PR TITLE
Add <title> tags to every page

### DIFF
--- a/open_humans/templates/account/delete.html
+++ b/open_humans/templates/account/delete.html
@@ -2,7 +2,7 @@
 
 {% load utilities %}
 
-{% block panel_title %}Delete My Account{% endblock %}
+{% block head_title %}Delete My Account{% endblock %}
 
 {% block panel_content %}
 <div class="row">

--- a/open_humans/templates/account/email_confirm.html
+++ b/open_humans/templates/account/email_confirm.html
@@ -1,6 +1,6 @@
 {% extends 'panel.html' %}
 
-{% block panel_title %}Confirm your email{% endblock %}
+{% block head_title %}Confirm your email{% endblock %}
 
 {% block panel_content %}
 <div class="row pad-all-sides">

--- a/open_humans/templates/account/login-oauth2.html
+++ b/open_humans/templates/account/login-oauth2.html
@@ -2,7 +2,7 @@
 
 {% load utilities %}
 
-{% block panel_title %}Connecting {{connection}}{% endblock %}
+{% block head_title %}Connecting {{connection}}{% endblock %}
 
 {% block panel_content %}
 <div class="row">

--- a/open_humans/templates/account/login.html
+++ b/open_humans/templates/account/login.html
@@ -2,7 +2,8 @@
 
 {% load utilities %}
 
-{% block panel_title %}Log in to Open Humans{% endblock %}
+{% block head_title %}Log in to Open Humans{% endblock %}
+{% block head_title_suffix %}{% endblock %}
 
 {% block panel_content %}
 <div class="row">

--- a/open_humans/templates/account/logout.html
+++ b/open_humans/templates/account/logout.html
@@ -1,8 +1,7 @@
 {% extends 'panel.html' %}
 
-{% block panel_title %}
-Log out of Open Humans
-{% endblock %}
+{% block head_title %}Log out of Open Humans{% endblock %}
+{% block head_title_suffix %}{% endblock %}
 
 {% block panel_content %}
 <div class="text-center" style="padding-bottom:30px;">

--- a/open_humans/templates/account/password_change.html
+++ b/open_humans/templates/account/password_change.html
@@ -3,7 +3,7 @@
 {% load bootstrap_tags %}
 {% load utilities %}
 
-{% block panel_title %}Change Password{% endblock %}
+{% block head_title %}Change Password{% endblock %}
 
 {% block panel_content %}
 <div class="row pad-all-sides">

--- a/open_humans/templates/account/password_reset.html
+++ b/open_humans/templates/account/password_reset.html
@@ -3,9 +3,8 @@
 {% load bootstrap_tags %}
 {% load utilities %}
 
-{% block panel_title %}
-Reset your Open Humans password
-{% endblock %}
+{% block head_title %}Reset your Open Humans password{% endblock %}
+{% block head_title_suffix %}{% endblock %}
 
 {% block panel_content %}
 <div class="pad-all-sides">

--- a/open_humans/templates/account/password_reset_sent.html
+++ b/open_humans/templates/account/password_reset_sent.html
@@ -1,6 +1,6 @@
 {% extends 'panel.html' %}
 
-{% block panel_title %}Password reset sent{% endblock %}
+{% block head_title %}Password reset sent{% endblock %}
 
 {% block panel_content %}
 <p>

--- a/open_humans/templates/account/password_reset_token.html
+++ b/open_humans/templates/account/password_reset_token.html
@@ -3,7 +3,7 @@
 {% load bootstrap_tags %}
 {% load utilities %}
 
-{% block panel_title %}Set your new password{% endblock %}
+{% block head_title %}Set your new password{% endblock %}
 
 {% block panel_content %}
 <div class="row">

--- a/open_humans/templates/account/password_reset_token_fail.html
+++ b/open_humans/templates/account/password_reset_token_fail.html
@@ -2,7 +2,7 @@
 
 {% load utilities %}
 
-{% block panel_title %}Bad token{% endblock %}
+{% block head_title %}Bad token{% endblock %}
 
 {% block panel_content %}
 <div class="row">

--- a/open_humans/templates/account/signup.html
+++ b/open_humans/templates/account/signup.html
@@ -1,8 +1,6 @@
 {% extends 'panel.html' %}
 
-{% block panel_title %}
-Create an Open Humans account
-{% endblock %}
+{% block head_title %}Create an Open Humans account{% endblock %}
 
 {% block panel_content %}
 <div class="row">

--- a/open_humans/templates/account/signup_closed.html
+++ b/open_humans/templates/account/signup_closed.html
@@ -1,6 +1,7 @@
 {% extends 'panel.html' %}
 
-{% block panel_title %}Open Humans is currently invite only{% endblock %}
+{% block head_title %}Open Humans is currently invite only{% endblock %}
+{% block head_title_suffix %}Open Humans is currently invite only{% endblock %}
 
 {% block panel_content %}
 <div class="row pad-all-sides">

--- a/open_humans/templates/base.html
+++ b/open_humans/templates/base.html
@@ -3,7 +3,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>{% block head_title %}Open Humans{% endblock %}</title>
+    <title>{% block head_title %}{% endblock %}{% block head_title_suffix %} - Open Humans{% endblock %}</title>
 
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/open_humans/templates/member/member-detail.html
+++ b/open_humans/templates/member/member-detail.html
@@ -2,6 +2,8 @@
 
 {% load static from staticfiles %}
 
+{% block head_title %}{{ member.user.username }}{% endblock %}
+
 {% block main %}
 <div style="margin-top:15px;">
   <div class="member-detail-panel">

--- a/open_humans/templates/member/member-email.html
+++ b/open_humans/templates/member/member-email.html
@@ -3,7 +3,8 @@
 {% load bootstrap_tags %}
 {% load static from staticfiles %}
 
-{% block panel_title %}Email Open Humans member{% endblock %}
+{% block head_title %}Email Open Humans member{% endblock %}
+{% block head_title_suffix %}{% endblock %}
 
 {% block panel_content %}
 <div class="row pad-all-sides">

--- a/open_humans/templates/member/member-list.html
+++ b/open_humans/templates/member/member-list.html
@@ -6,6 +6,8 @@
 {% load thumbnail %}
 {% load static %}
 
+{% block head_title %}Members{% endblock %}
+
 {% block main %}
 
 <h3>Members <small>{{ page_obj.start_index|intcomma }} to

--- a/open_humans/templates/member/my-member-change-email.html
+++ b/open_humans/templates/member/my-member-change-email.html
@@ -3,7 +3,7 @@
 {% load bootstrap_tags %}
 {% load utilities %}
 
-{% block panel_title %}Change Email{% endblock %}
+{% block head_title %}Change Email{% endblock %}
 
 {% block panel_content %}
 <div class="row pad-all-sides">

--- a/open_humans/templates/member/my-member-change-name.html
+++ b/open_humans/templates/member/my-member-change-name.html
@@ -3,7 +3,7 @@
 {% load bootstrap_tags %}
 {% load utilities %}
 
-{% block panel_title %}Change Name{% endblock %}
+{% block head_title %}Change Name{% endblock %}
 
 {% block panel_content %}
 <div class="row pad-all-sides">

--- a/open_humans/templates/member/my-member-connections-delete.html
+++ b/open_humans/templates/member/my-member-connections-delete.html
@@ -2,7 +2,7 @@
 
 {% load utilities %}
 
-{% block panel_title %}Confirm removal{% endblock %}
+{% block head_title %}Confirm removal{% endblock %}
 
 {% block panel_content %}
 <div class="row">

--- a/open_humans/templates/member/my-member-connections.html
+++ b/open_humans/templates/member/my-member-connections.html
@@ -1,5 +1,7 @@
 {% extends 'member/my-member-dashboard.html' %}
 
+{% block head_title %}Manage connections{% endblock %}
+
 {% block dashboard_main %}
 <div class="panel panel-default pad-all-sides">
   <h3 style="border-bottom: solid 1px #eee;margin-top:0px;margin-bottom:20px;">Manage connections</h3>

--- a/open_humans/templates/member/my-member-dashboard.html
+++ b/open_humans/templates/member/my-member-dashboard.html
@@ -2,6 +2,8 @@
 
 {% load utilities %}
 
+{% block head_title %}Member dashboard{% endblock %}
+
 {% block main %}
 <div class="row" style="margin-top:5px;">
   <div class="col-sm-3">

--- a/open_humans/templates/member/my-member-profile-edit.html
+++ b/open_humans/templates/member/my-member-profile-edit.html
@@ -2,6 +2,8 @@
 
 {% load bootstrap_tags %}
 
+{% block head_title %}Edit profile{% endblock %}
+
 {% block dashboard_main %}
   <form class="form-horizontal" role="form" method="post"
     action="{% url 'my-member-profile-edit' %}" id="member-profile-edit-form"

--- a/open_humans/templates/member/my-member-research-data.html
+++ b/open_humans/templates/member/my-member-research-data.html
@@ -3,6 +3,8 @@
 {% load data_import %}
 {% load utilities %}
 
+{% block head_title %}Research data{% endblock %}
+
 {% block dashboard_main %}
 <div class="panel panel-default pad-all-sides">
   {% for source, task in data_retrieval_tasks.items %}

--- a/open_humans/templates/member/my-member-settings.html
+++ b/open_humans/templates/member/my-member-settings.html
@@ -2,6 +2,8 @@
 
 {% load bootstrap_tags %}
 
+{% block head_title %}Settings{% endblock %}
+
 {% block dashboard_main %}
 <div class="panel panel-default pad-all-sides">
   <h3>Account Settings</h3>

--- a/open_humans/templates/member/my-member-source-data-files-delete.html
+++ b/open_humans/templates/member/my-member-source-data-files-delete.html
@@ -2,7 +2,7 @@
 
 {% load utilities %}
 
-{% block panel_title %}Confirm deletion{% endblock %}
+{% block head_title %}Confirm deletion{% endblock %}
 
 {% block panel_content %}
 <div class="row">

--- a/open_humans/templates/member/my-member-study-grants-delete.html
+++ b/open_humans/templates/member/my-member-study-grants-delete.html
@@ -2,7 +2,7 @@
 
 {% load utilities %}
 
-{% block panel_title %}Confirm removal{% endblock %}
+{% block head_title %}Confirm removal{% endblock %}
 
 {% block panel_content %}
 <div class="row">

--- a/open_humans/templates/member/welcome-connecting.html
+++ b/open_humans/templates/member/welcome-connecting.html
@@ -2,6 +2,8 @@
 
 {% load static from staticfiles %}
 
+{% block head_title %}Connecting studies{% endblock %}
+
 {% block main %}
 <div class="row">
   <div class="col-xs-12 col-sm-3 col-lg-2">

--- a/open_humans/templates/member/welcome-data-import.html
+++ b/open_humans/templates/member/welcome-data-import.html
@@ -2,6 +2,8 @@
 
 {% load static from staticfiles %}
 
+{% block head_title %}Importing data{% endblock %}
+
 {% block main %}
 <div class="row">
   <div class="col-xs-12 col-sm-3 col-lg-2">

--- a/open_humans/templates/member/welcome-enrollment.html
+++ b/open_humans/templates/member/welcome-enrollment.html
@@ -2,6 +2,8 @@
 
 {% load static from staticfiles %}
 
+{% block head_title %}Enrolling in studies{% endblock %}
+
 {% block main %}
 <div class="row">
   <div class="col-xs-12 col-sm-3 col-lg-2">

--- a/open_humans/templates/member/welcome-profile.html
+++ b/open_humans/templates/member/welcome-profile.html
@@ -2,6 +2,8 @@
 
 {% load static from staticfiles %}
 
+{% block head_title %}Expand your profile{% endblock %}
+
 {% block main %}
 <div class="row">
   <div class="col-xs-12 col-sm-3 col-lg-2">

--- a/open_humans/templates/member/welcome.html
+++ b/open_humans/templates/member/welcome.html
@@ -2,6 +2,8 @@
 
 {% load static from staticfiles %}
 
+{% block head_title %}Welcome{% endblock %}
+
 {% block main %}
 <div class="row">
   <div class="col-xs-12 col-sm-3 col-lg-2">

--- a/open_humans/templates/oauth2_provider/authorize.html
+++ b/open_humans/templates/oauth2_provider/authorize.html
@@ -2,7 +2,7 @@
 
 {% load utilities %}
 
-{% block panel_title %}
+{% block head_title %}
 {% if not error %}
 Authorization Request
 {% else %}

--- a/open_humans/templates/oauth2_provider/finalize.html
+++ b/open_humans/templates/oauth2_provider/finalize.html
@@ -2,7 +2,7 @@
 
 {% load utilities %}
 
-{% block panel_title %}
+{% block head_title %}
 {% if not error %}
 Finalize {{ application.name }} data connection
 {% else %}

--- a/open_humans/templates/pages/about.html
+++ b/open_humans/templates/pages/about.html
@@ -2,6 +2,8 @@
 
 {% load static from staticfiles %}
 
+{% block head_title %}About{% endblock %}
+
 {% block main %}
 <ul class="nav nav-pills below-navbar">
   <li class="active">

--- a/open_humans/templates/pages/activities.html
+++ b/open_humans/templates/pages/activities.html
@@ -2,6 +2,8 @@
 
 {% load static from staticfiles %}
 
+{% block head_title %}Activities{% endblock %}
+
 {% block main %}
 <div class="row">
   <div class="col-xs-12">

--- a/open_humans/templates/pages/community_guidelines.html
+++ b/open_humans/templates/pages/community_guidelines.html
@@ -1,5 +1,7 @@
 {% extends 'base.html' %}
 
+{% block head_title %}Community guidelines{% endblock %}
+
 {% block main %}
 <ul class="nav nav-pills below-navbar">
   <li class="active">

--- a/open_humans/templates/pages/contact_us.html
+++ b/open_humans/templates/pages/contact_us.html
@@ -1,5 +1,7 @@
 {% extends 'base.html' %}
 
+{% block head_title %}Contact us{% endblock %}
+
 {% block main %}
 <h1>Contact us</h1>
 

--- a/open_humans/templates/pages/copyright-policy.html
+++ b/open_humans/templates/pages/copyright-policy.html
@@ -1,5 +1,7 @@
 {% extends 'base.html' %}
 
+{% block head_title %}Copyright policy{% endblock %}
+
 {% block main %}
 <div class="row">
   <div class="col-lg-12">

--- a/open_humans/templates/pages/data-use.html
+++ b/open_humans/templates/pages/data-use.html
@@ -1,5 +1,7 @@
 {% extends 'base.html' %}
 
+{% block head_title %}Data use policy{% endblock %}
+
 {% block main %}
 <div class="row">
   <div class="col-lg-12">

--- a/open_humans/templates/pages/faq.html
+++ b/open_humans/templates/pages/faq.html
@@ -2,6 +2,8 @@
 
 {% load static from staticfiles %}
 
+{% block head_title %}FAQ{% endblock %}
+
 {% block main %}
 <div class="row">
   <div class="col-lg-12">

--- a/open_humans/templates/pages/home.html
+++ b/open_humans/templates/pages/home.html
@@ -2,6 +2,9 @@
 
 {% load static from staticfiles %}
 
+{% block head_title %}Open Humans{% endblock %}
+{% block head_title_suffix %}{% endblock %}
+
 {% block body_main %}
 
 {% if user.is_authenticated %}

--- a/open_humans/templates/pages/news.html
+++ b/open_humans/templates/pages/news.html
@@ -1,5 +1,7 @@
 {% extends 'base.html' %}
 
+{% block head_title %}News{% endblock %}
+
 {% block main %}
 <div class="row">
   <div class="col-lg-12">

--- a/open_humans/templates/pages/pgp-interstitial.html
+++ b/open_humans/templates/pages/pgp-interstitial.html
@@ -2,7 +2,7 @@
 
 {% load utilities %}
 
-{% block panel_title %}Quick note...{% endblock %}
+{% block head_title %}Quick note...{% endblock %}
 
 {% block panel_content %}
 <div class="row pad-all-sides">

--- a/open_humans/templates/pages/research.html
+++ b/open_humans/templates/pages/research.html
@@ -2,6 +2,8 @@
 
 {% load static from staticfiles %}
 
+{% block head_title %}Research{% endblock %}
+
 {% block main %}
 <div class="row">
   <div class="col-xs-12">

--- a/open_humans/templates/pages/statistics.html
+++ b/open_humans/templates/pages/statistics.html
@@ -2,6 +2,8 @@
 
 {% load humanize %}
 
+{% block head_title %}Statistics{% endblock %}
+
 {% block main %}
 <div class="row">
   <div class="col-xs-12">

--- a/open_humans/templates/pages/terms.html
+++ b/open_humans/templates/pages/terms.html
@@ -1,5 +1,7 @@
 {% extends 'base.html' %}
 
+{% block head_title %}Terms of use{% endblock %}
+
 {% block main %}
 <div class="row">
   <div class="col-lg-12">

--- a/open_humans/templates/panel.html
+++ b/open_humans/templates/panel.html
@@ -17,7 +17,7 @@
       {% endfor %}
     {% endif %}
 
-    <h3 class="page-header">{% block panel_title %}{% endblock %}</h3>
+    <h3 class="page-header">{% block head_title %}{% endblock %}</h3>
 
     {% block panel_content %}{% endblock %}
   </div>


### PR DESCRIPTION
This PR adds a `head_title_suffix` that defaults to " - Open Humans" and changes all uses of `panel_title` to `head_title`. It also specifies titles where no title was previously specified.

For titles that contain "Open Humans" like "Log in to Open Humans" I set `head_title_suffix` to an empty string.

(I noticed that the `<title>` of every page was set to "Open Humans")